### PR TITLE
Fix doc comment for the get call.

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -112,7 +112,7 @@ class Manager {
   //   * `name` (required) {String} e.g. go-plus
   //   * `packageName` (required) {String} e.g. goimports
   //   * `packagePath` (required) {String} e.g. golang.org/x/tools/cmd/goimports
-  //   * `type` (required) {String} e.g. golang.org/x/tools/cmd/goimports
+  //   * `type` (required) {String} one of 'missing' or 'outdated' (used to customize the prompt)
   get (options) {
     if (!options || !options.name || !options.packageName || !options.packagePath || !options.type) {
       return Promise.resolve(false)


### PR DESCRIPTION
The 'type' option was incorrectly documented.
It is used to customize the prompt that the user sees.
